### PR TITLE
Add isPvP flag to startAnteTimer action

### DIFF
--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -672,7 +672,7 @@ const receiveNemesisStatsActionHandler = (
 };
 
 const startAnteTimerAction = (
-	{ time }: ActionHandlerArgs<ActionStartAnteTimer>,
+	{ time, isPvP }: ActionHandlerArgs<ActionStartAnteTimer>,
 	client: Client,
 ) => {
 	const [lobby, enemy] = getEnemy(client);
@@ -680,6 +680,7 @@ const startAnteTimerAction = (
 	enemy.sendAction({
 		action: "startAnteTimer",
 		time,
+		...(isPvP ? { isPvP: true } : {}),
 	});
 };
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -60,7 +60,7 @@ export type ActionGetNemesisDeckRequest = { action: 'getNemesisDeck' }
 export type ActionReceiveNemesisDeckRequest = { action: 'receiveNemesisDeck', cards: string }
 export type ActionGetNemesisStatsRequest = { action: 'endGameStatsRequested' }
 export type ActionReceiveNemesisStatsRequest = { action: 'nemesisEndGameStats', reroll_count: string, reroll_cost_total:string, vouchers:string }
-export type ActionStartAnteTimer = { action: 'startAnteTimer', time: number }
+export type ActionStartAnteTimer = { action: 'startAnteTimer', time: number, isPvP?: boolean }
 export type ActionPauseAnteTimer = { action: 'pauseAnteTimer', time: number }
 // Handy Actions (Server to Client)
 export type ActionHandyMPExtensionLobbyEnabled = { action: 'handyMPExtensionLobbyEnabled', enabled: boolean }
@@ -159,7 +159,7 @@ export type ActionGetNemesisDeckResponse = { action: 'getNemesisDeck' }
 export type ActionReceiveNemesisDeckResponse = { action: 'receiveNemesisDeck', cards: string }
 export type ActionGetNemesisStatsResponse = { action: 'endGameStatsRequested' }
 export type ActionReceiveNemesisStatsResponse = { action: 'nemesisEndGameStats', reroll_count: string,reroll_cost_total:string, vouchers:string }
-export type ActionStartAnteTimerRequest = { action: 'startAnteTimer', time: number }
+export type ActionStartAnteTimerRequest = { action: 'startAnteTimer', time: number, isPvP?: boolean }
 export type ActionPauseAnteTimerRequest = { action: 'pauseAnteTimer', time: number }
 export type ActionFailTimer = { action: 'failTimer' }
 export type ActionFailPvPTimer = { action: 'failPvPTimer' }


### PR DESCRIPTION
## Summary
Added an optional `isPvP` boolean flag to the `startAnteTimer` action to support PvP-specific timer behavior.

## Key Changes
- Updated `ActionStartAnteTimer` type definition to include optional `isPvP?: boolean` property
- Updated `ActionStartAnteTimerRequest` type definition with the same optional property
- Modified `startAnteTimerAction` handler to accept and forward the `isPvP` flag to the enemy client
- The flag is conditionally included in the action payload only when `isPvP` is true

## Implementation Details
- The `isPvP` parameter is optional to maintain backward compatibility with existing code
- The flag is conditionally spread into the action object using `...(isPvP ? { isPvP: true } : {})` to avoid sending undefined values
- This allows the receiving client to differentiate between PvP and non-PvP ante timer scenarios

https://claude.ai/code/session_016kQrzLNB5kdL18tfVP4gfj