### PR TITLE
Opponent's hands display & server-side PvP timer

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,5 +1,5 @@
 import type Client from "./Client.js";
-import type { InsaneInt } from "./InsaneInt.js";
+import { InsaneInt } from "./InsaneInt.js";
 import GameModes from "./GameMode.js";
 import type {
 	ActionLobbyInfo,
@@ -350,6 +350,7 @@ class Lobby {
 			this.host.setLocation("Blind Select");
 			this.host.furthestBlind = 0;
 			this.host.skips = 0;
+            this.host.score = new InsaneInt(0, 0, 0);
 		}
 		if (this.guest) {
 			this.guest.isReady = false;
@@ -357,6 +358,7 @@ class Lobby {
 			this.guest.setLocation("Blind Select");
 			this.guest.furthestBlind = 0;
 			this.guest.skips = 0;
+            this.guest.score = new InsaneInt(0, 0, 0);
 		}
 		this.tcgBets.clear();
 		this.firstReadyAt = null;

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -248,8 +248,9 @@ const playHandAction = (
 	// player has genuinely played this blind. Hand counts can vary in this game, so
 	// handsLeft is not a reliable signal.
 	const playedRealHand = client.score.greaterThan(new InsaneInt(0, 0, 0));
-	const wasFirstHand = playedRealHand && !client.playedThisBlind;
 	if (playedRealHand) client.playedThisBlind = true;
+
+    const isHostTurn = lobby.host.score.equalTo(lobby.guest.score) ? lobby.host.firstReady : lobby.host.score.greaterThan(lobby.guest.score)
 
 	// Reveal our score to the enemy immediately, unless we're withholding it
 	// until they have also committed a hand this blind. This stops a player from
@@ -261,6 +262,7 @@ const playHandAction = (
 			score: client.score.toString(),
 			skips: client.skips,
 			lives: client.lives,
+            pvpTimerOrder: isHostTurn ? "host" : "guest"
 		});
 	} else {
         enemy.sendAction({
@@ -269,7 +271,7 @@ const playHandAction = (
 			score: null,
 			skips: client.skips,
 			lives: client.lives,
-            noScore: true
+            noScore: true,
 		});
     }
 
@@ -277,13 +279,14 @@ const playHandAction = (
 	// they have already played, this is the score that was withheld until now;
 	// if they haven't, it's their reset state (score 0, full hands) — enough for
 	// us to stop masking their hand count now that we've committed our own hand.
-	if (hideScore && wasFirstHand) {
+	if (!hideScore || client.playedThisBlind) {
 		client.sendAction({
 			action: "enemyInfo",
 			handsLeft: enemy.handsLeft,
 			score: enemy.score.toString(),
 			skips: enemy.skips,
 			lives: enemy.lives,
+            pvpTimerOrder: isHostTurn ? "host" : "guest"
 		});
 	} else {
         client.sendAction({
@@ -292,7 +295,7 @@ const playHandAction = (
 			score: null,
 			skips: enemy.skips,
 			lives: enemy.lives,
-            noScore: true
+            noScore: true,
 		});
     }
 

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -262,7 +262,16 @@ const playHandAction = (
 			skips: client.skips,
 			lives: client.lives,
 		});
-	}
+	} else {
+        enemy.sendAction({
+			action: "enemyInfo",
+			handsLeft,
+			score: null,
+			skips: client.skips,
+			lives: client.lives,
+            noScore: true
+		});
+    }
 
 	// On our first hand of the blind, send the enemy's current state to us. If
 	// they have already played, this is the score that was withheld until now;
@@ -276,7 +285,16 @@ const playHandAction = (
 			skips: enemy.skips,
 			lives: enemy.lives,
 		});
-	}
+	} else {
+        client.sendAction({
+			action: "enemyInfo",
+			handsLeft: enemy.handsLeft,
+			score: null,
+			skips: enemy.skips,
+			lives: enemy.lives,
+            noScore: true
+		});
+    }
 
 	// This info is only sent on a boss blind, so it shouldn't
 	// affect other blinds

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -39,6 +39,7 @@ export type ActionEnemyInfo = {
 	handsLeft: number
 	skips: number
 	lives: number
+    pvpTimerOrder?: "guest" | "host"
 } | {
 	action: 'enemyInfo'
     noScore: true
@@ -46,6 +47,7 @@ export type ActionEnemyInfo = {
 	handsLeft: number
 	skips: number
 	lives: number
+    pvpTimerOrder?: "guest" | "host"
 }
 export type ActionEndPvP = { action: 'endPvP'; lost: boolean, pvpTimerLost?: boolean }
 export type ActionLobbyOptions = { action: 'lobbyOptions', gamemode: string }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -39,6 +39,13 @@ export type ActionEnemyInfo = {
 	handsLeft: number
 	skips: number
 	lives: number
+} | {
+	action: 'enemyInfo'
+    noScore: true
+	score: null
+	handsLeft: number
+	skips: number
+	lives: number
 }
 export type ActionEndPvP = { action: 'endPvP'; lost: boolean, pvpTimerLost?: boolean }
 export type ActionLobbyOptions = { action: 'lobbyOptions', gamemode: string }


### PR DESCRIPTION
- PvP timer: Turn order now controlled by server instead of client (`pvpTimerOrder = "host" | "guest"`)
- enemyInfo: hands left sended always, score sended only after first hand played (added flag `noScore`)