### PR TITLE
Timer sync implementation

### DIFF
--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -941,7 +941,7 @@ const dataSyncAction = (
 
     enemy.sendAction({
         action: "dataSync",
-        timer: timer
+        timer: Number.isNaN(timer) ? undefined : Number(timer)
     })
 }
 

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -37,6 +37,7 @@ import type {
 	ActionModdedRequest,
 	ActionHandyMPExtensionEnable,
 	ActionHandyMPExtensionDisable,
+    ActionDataSyncRequest,
 } from "./actions.js";
 import { generateSeed } from "./utils.js";
 import {
@@ -931,6 +932,19 @@ const streamLogLinesAction = (
 	});
 };
 
+const dataSyncAction = (
+    { timer }: ActionHandlerArgs<ActionDataSyncRequest>,
+    client: Client,
+ ) => {
+	const [lobby, enemy] = getEnemy(client);
+    if (!lobby || !enemy) return
+
+    enemy.sendAction({
+        action: "dataSync",
+        timer: timer
+    })
+}
+
 export const actionHandlers = {
 	username: usernameAction,
 	createLobby: createLobbyAction,
@@ -985,6 +999,7 @@ export const actionHandlers = {
 	handyMPExtensionEnable: handyMPExtensionEnable,
 	handyMPExtensionDisable: handyMPExtensionDisable,
     failPvPTimer: failPvPTimerAction,
+    dataSync: dataSyncAction,
 } satisfies Partial<ActionHandlers>;
 
 /** Server-internal handler for connection drops (not a client action) */

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -62,6 +62,7 @@ export type ActionGetNemesisStatsRequest = { action: 'endGameStatsRequested' }
 export type ActionReceiveNemesisStatsRequest = { action: 'nemesisEndGameStats', reroll_count: string, reroll_cost_total:string, vouchers:string }
 export type ActionStartAnteTimer = { action: 'startAnteTimer', time: number, isPvP?: boolean }
 export type ActionPauseAnteTimer = { action: 'pauseAnteTimer', time: number }
+export type ActionDataSyncResponse = { action: "dataSync", timer?: number }
 // Handy Actions (Server to Client)
 export type ActionHandyMPExtensionLobbyEnabled = { action: 'handyMPExtensionLobbyEnabled', enabled: boolean }
 // TCG Actions (Server to Client)
@@ -115,6 +116,7 @@ export type ActionServerToClient =
 	| ActionTcgPlayerStatus
 	| ActionTcgStartTurn
 	| ActionModded
+    | ActionDataSyncResponse
     | ActionHandyMPExtensionLobbyEnabled
 // Client to Server
 export type ActionUsername = { action: 'username'; username: string; modHash: string }
@@ -175,6 +177,7 @@ export type ActionTcgEndTurn = { action: 'tcgEndTurn', [key: string]: unknown }
 export type ActionModdedRequest = { action: 'moddedAction', modId: string, modAction: string, target?: 'nemesis' | 'all', [key: string]: unknown }
 // Handy Actions (Client to Server)
 export type ActionRejoinLobby = { action: 'rejoinLobby'; code: string; reconnectToken: string }
+export type ActionDataSyncRequest = { action: "dataSync", timer?: number }
 export type ActionHandyMPExtensionEnable = { action: 'handyMPExtensionEnable', [key: string]: unknown }
 export type ActionHandyMPExtensionDisable = { action: 'handyMPExtensionDisable', [key: string]: unknown }
 export type ActionClientToServer =
@@ -230,6 +233,7 @@ export type ActionClientToServer =
 	| ActionTcgEndTurn
 	| ActionModdedRequest
 	| ActionRejoinLobby
+    | ActionDataSyncRequest
     | ActionHandyMPExtensionEnable
     | ActionHandyMPExtensionDisable
 // Utility actions

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import type {
 	ActionRejoinLobby,
     ActionHandyMPExtensionEnable,
     ActionHandyMPExtensionDisable,
+    ActionDataSyncRequest,
 } from './actions.js'
 import { InsaneInt } from './InsaneInt.js'
 import { ABUSE_CONFIG, ConnectionMeter } from './abuse.js'
@@ -507,6 +508,11 @@ const server = createServer((socket) => {
 							client,
 						)
 						break
+                    case 'dataSync':
+                        actionHandlers.dataSync(
+                            actionArgs as ActionHandlerArgs<ActionDataSyncRequest>,
+                            client,
+                        )
 					case 'handyMPExtensionEnable':
 						actionHandlers.handyMPExtensionEnable(
 							actionArgs as ActionHandlerArgs<ActionHandyMPExtensionEnable>,

--- a/src/main.ts
+++ b/src/main.ts
@@ -513,6 +513,7 @@ const server = createServer((socket) => {
                             actionArgs as ActionHandlerArgs<ActionDataSyncRequest>,
                             client,
                         )
+                        break
 					case 'handyMPExtensionEnable':
 						actionHandlers.handyMPExtensionEnable(
 							actionArgs as ActionHandlerArgs<ActionHandyMPExtensionEnable>,


### PR DESCRIPTION
This PR adds an action `dataSync`, which intended to send info from one client to another in 5 seconds interval for syncing or displaying some values.
Currently it's used for sending client's timer value to display it on other client's UI, but can be extended to transport any other useful info.