### PR TITLE
Fix ante/PvP timer life loss blocking blind loss life loss

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -47,7 +47,12 @@ class Client {
 	skips = 0
 	furthestBlind = 0
 
-	livesBlocker = false
+	/** Guards against a duplicate life loss from the *same* cause firing twice
+	 *  (e.g. two failRound call sites for one blind failure). Kept separate per
+	 *  cause so a timer expiry and a blind/round loss can each cost a life even
+	 *  when they happen within the same round. */
+	roundLivesBlocker = false
+	timerLivesBlocker = false
 
 	location = 'loc_selecting'
 
@@ -96,24 +101,35 @@ class Client {
 	}
 
 	resetBlocker = () => {
-		this.livesBlocker = false
+		this.roundLivesBlocker = false
+		this.timerLivesBlocker = false
 	}
 
-	loseLife = () => {
-		if (!this.livesBlocker) {
-			this.lives -= 1
-			this.livesBlocker = true
-			this.sendAction({ action: "playerInfo", lives: this.lives });
-			if (this.lobby && this.lobby.host && this.lobby.guest) {
-				const enemy = this.lobby.host === this ? this.lobby.guest : this.lobby.host
-				enemy.sendAction({
-					action: "enemyInfo",
-					handsLeft: this.handsLeft,
-					score: this.score.toString(),
-					skips: this.skips,
-					lives: this.lives,
-				});
-			}
+	/**
+	 * @param cause 'round' for a blind/PvP-hand loss, 'timer' for an ante/PvP
+	 * timer expiry. Each cause has its own once-per-round guard, so a timer
+	 * expiry and a round loss can both cost a life in the same round.
+	 */
+	loseLife = (cause: 'round' | 'timer' = 'round') => {
+		const alreadyLost = cause === 'timer' ? this.timerLivesBlocker : this.roundLivesBlocker
+		if (alreadyLost) return
+
+		this.lives -= 1
+		if (cause === 'timer') {
+			this.timerLivesBlocker = true
+		} else {
+			this.roundLivesBlocker = true
+		}
+		this.sendAction({ action: "playerInfo", lives: this.lives });
+		if (this.lobby && this.lobby.host && this.lobby.guest) {
+			const enemy = this.lobby.host === this ? this.lobby.guest : this.lobby.host
+			enemy.sendAction({
+				action: "enemyInfo",
+				handsLeft: this.handsLeft,
+				score: this.score.toString(),
+				skips: this.skips,
+				lives: this.lives,
+			});
 		}
 	}
 

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -42,7 +42,8 @@ interface SavedGameState {
 	isReady: boolean;
 	firstReady: boolean;
 	isReadyLobby: boolean;
-	livesBlocker: boolean;
+	roundLivesBlocker: boolean;
+	timerLivesBlocker: boolean;
 	location: string;
 	username: string;
 	modHash: string;
@@ -171,7 +172,8 @@ class Lobby {
 				isReady: client.isReady,
 				firstReady: client.firstReady,
 				isReadyLobby: client.isReadyLobby,
-				livesBlocker: client.livesBlocker,
+				roundLivesBlocker: client.roundLivesBlocker,
+				timerLivesBlocker: client.timerLivesBlocker,
 				location: client.location,
 				username: client.username,
 				modHash: client.modHash,
@@ -217,7 +219,8 @@ class Lobby {
 		newClient.isReady = savedState.isReady;
 		newClient.firstReady = savedState.firstReady;
 		newClient.isReadyLobby = savedState.isReadyLobby;
-		newClient.livesBlocker = savedState.livesBlocker;
+		newClient.roundLivesBlocker = savedState.roundLivesBlocker;
+		newClient.timerLivesBlocker = savedState.timerLivesBlocker;
 		newClient.location = savedState.location;
 		newClient.username = savedState.username;
 		newClient.modHash = savedState.modHash;

--- a/src/actionHandlers.ts
+++ b/src/actionHandlers.ts
@@ -316,7 +316,7 @@ const playHandAction = (
 			roundWinner.id === lobby.host.id ? lobby.guest : lobby.host;
 
 		if (!lobby.host.score.equalTo(lobby.guest.score)) {
-			roundLoser.loseLife();
+			roundLoser.loseLife('round');
 
 			// If no lives are left, we end the game
 			if (lobby.host.lives <= 0 || lobby.guest.lives <= 0) {
@@ -348,7 +348,7 @@ const failPvPTimerAction = (
 ) => {
     const lobby = client.lobby;
 
-	client.loseLife();
+	client.loseLife('timer');
 
 	if (!lobby) return;
 
@@ -415,7 +415,7 @@ const failRoundAction = (client: Client) => {
 	if (!lobby || !enemy) return;
 
 	if (lobby.options.death_on_round_loss) {
-		client.loseLife();
+		client.loseLife('round');
 	}
 
 	if (client.lives === 0) {
@@ -721,7 +721,7 @@ const pauseAnteTimerAction = (
 const failTimerAction = (client: Client) => {
 	const lobby = client.lobby;
 
-	client.loseLife();
+	client.loseLife('timer');
 
 	if (!lobby) return;
 


### PR DESCRIPTION
## Summary

- `Client.loseLife()` used a single `livesBlocker` flag as a once-per-round guard against duplicate life loss. It's only reset when a new round begins (client sends `newRound` on blind select).
- That meant if a player lost a life to the ante timer expiring (`failTimer`) partway through a blind, the guard tripped for the rest of that round — so if they then also failed the blind outright (`failRound`), the second, legitimate life loss was silently swallowed.
- The same shared-guard problem applies to `failPvPTimer` (PvP timer expiry) versus the round-loss life loss awarded in `playHand` when the PvP hand comparison resolves — both could fire in principle within the same round and only the first would register.

## Fix

- Split the single `livesBlocker` into two independent guards on `Client`: `roundLivesBlocker` (blind/PvP-hand round loss) and `timerLivesBlocker` (ante/PvP timer expiry).
- `loseLife(cause: 'round' | 'timer')` now checks/sets only the guard for that cause, so a timer-caused loss and a round-caused loss can each independently cost a life within the same round, while still preventing duplicate calls for the *same* cause (e.g. two `failRound` call sites for one blind failure) from double-charging.
- `resetBlocker()` clears both guards, and the reconnect/disconnect save-and-restore state in `Lobby.ts` was updated to persist both flags instead of the old single one.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors.
- [ ] Manual playtest: let the ante timer expire once during a blind (confirm a life is lost), then fail that same blind by running out of hands (confirm a second, separate life is lost).
- [ ] Manual playtest: repeat for the PvP timer during a PvP blind alongside a normal PvP round loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfHoBerR5bptR9Jx74kobR)_