### PR TITLE
Hash a version an admin manually points a mod at (Branch/Release source edit)

### DIFF
--- a/apps/server/src/features/mods/mods-sync.service.ts
+++ b/apps/server/src/features/mods/mods-sync.service.ts
@@ -11,11 +11,12 @@ import {
 	pruneModsMissingFrom,
 	storeComputedHash,
 	upsertModFromIndex,
+	upsertVersionRow,
 } from '../../infrastructure/gateways/mods.gateway.js'
 import { checkCustomModVersion } from './custom-mod-version-check.service.js'
 import { relocateModRoot } from './mod-archive-flatten.js'
-import { resolveReliableDownloadUrl } from './mod-source-classifier.js'
 import { computeModFolderHash } from './mod-folder-hash.js'
+import { resolveReliableDownloadUrl } from './mod-source-classifier.js'
 import { fetchUpstreamModIndex } from './upstream-mod-index.service.js'
 
 export interface ModRegistrySyncSummary {
@@ -139,7 +140,11 @@ async function runHashPool(
 				if (existingHash) continue
 			}
 
-			const hash = await computeModFolderHashForRelease(modId, version, downloadUrl)
+			const hash = await computeModFolderHashForRelease(
+				modId,
+				version,
+				downloadUrl,
+			)
 			if (hash) {
 				await storeComputedHash(modId, version, hash)
 				hashed++
@@ -207,6 +212,53 @@ export async function recomputeAllModHashes(modIds?: string[]): Promise<void> {
 			`[mods-sync] Failed (see earlier [mods-sync] Failed to hash lines above for why): ${failed
 				.map((f) => `${f.modId}@${f.version}`)
 				.join(', ')}`,
+		)
+	}
+}
+
+// Closes a real gap in the admin-edit path: webadmin/mods.route.ts's
+// resolveSourceInputField() resolves a fresh latestVersion/latestDownloadUrl
+// for an admin's Branch/Release source-type edit, but the PATCH/POST
+// handlers that call it only ever wrote those two fields onto the
+// mod_registry row itself - never into mod_registry_versions, and never
+// hashed anything. That version then had no way to *ever* get hashed:
+// hashAll()'s candidates come from the freshly-fetched upstream index entry
+// (or, for a custom mod, checkCustomModVersion()'s own detection) - neither
+// one has any idea an admin manually pointed a mod somewhere else, so an
+// admin-overridden version could sit there indefinitely with no row and no
+// hash no matter how many times the regular sync or the "Sync now" button
+// ran. Confirmed live as the actual cause of a real report: Blueprint's
+// admin-pinned release tag never got a stored hash, and could never even
+// be *selected* as the ranked-version pin (the admin UI's dropdown for a
+// 'release' mod only offers versions already present in
+// mod_registry_versions).
+//
+// Call right after resolving a Branch/Release source edit, before the
+// request responds - synchronous/awaited on purpose (matches
+// resolveSourceInput()'s own "admin needs to know immediately, not have
+// this silently fail in the background" philosophy), but best-effort: a
+// failed fetch/hash here is logged, not thrown - the field edit itself
+// already succeeded and shouldn't be rolled back over a transient hashing
+// failure, which the regular sync or a follow-up manual retry can still
+// recover (this function is safely re-callable - upsertVersionRow()
+// upserts, and getStoredHash()'s short-circuit means a second call after a
+// first success is a no-op).
+export async function ensureVersionHashed(
+	modId: string,
+	version: string,
+	downloadUrl: string,
+): Promise<void> {
+	await upsertVersionRow(modId, version, downloadUrl)
+
+	const existingHash = await getStoredHash(modId, version)
+	if (existingHash) return
+
+	const hash = await computeModFolderHashForRelease(modId, version, downloadUrl)
+	if (hash) {
+		await storeComputedHash(modId, version, hash)
+	} else {
+		console.error(
+			`[mods-sync] Couldn't hash ${modId}@${version} right after an admin source edit - it has no ranked-eligible hash yet; the regular sync won't retry this on its own (it only re-checks its own upstream/custom-mod-detected versions) - re-saving the same source edit will retry this too.`,
 		)
 	}
 }

--- a/apps/server/src/features/webadmin/mods.route.ts
+++ b/apps/server/src/features/webadmin/mods.route.ts
@@ -7,6 +7,7 @@ import {
 	deleteProfile,
 	getProfileById,
 	getPublicModById,
+	getStoredHash,
 	listProfiles,
 	listPublicMods,
 	removeProfileEntry,
@@ -26,7 +27,7 @@ import {
 	resolveSourceInput,
 } from '../mods/custom-mod-version-check.service.js'
 import { classifyDownloadUrl } from '../mods/mod-source-classifier.js'
-import { syncModRegistry } from '../mods/mods-sync.service.js'
+import { ensureVersionHashed, syncModRegistry } from '../mods/mods-sync.service.js'
 
 // Validates+resolves an admin-supplied `sourceInput` (see mod-form-dialog.tsx
 // and custom-mod-version-check.service.ts's resolveSourceInput doc comment)
@@ -190,7 +191,36 @@ router.put('/mods/:modId', async (req, res, next) => {
 					sourceType === 'release' &&
 					!mod.versions.some((v) => v.version === rankedVersion)
 				) {
-					throw new AppError('Not a known version of this mod', 400)
+					// Recovery path, not the normal case: the mod's own current
+					// latestVersion should always be a legal ranked pin, even if
+					// it has no mod_registry_versions row/hash yet. That gap
+					// normally closes itself right after a Branch/Release source
+					// edit (see ensureVersionHashed()'s own comment) - but the
+					// admin UI's PATCH is diff-based, only resending sourceInput
+					// when something in it actually changed, so an admin who
+					// already saved the right source once (and is now just stuck
+					// with an unhashed version - see Blueprint's real-world case)
+					// has no way to re-trigger that from the edit dialog alone.
+					// Retry hashing right now, once, for exactly this one
+					// recoverable case - mod.latestDownloadUrl is already known-
+					// correct for mod.latestVersion, there's nothing to resolve,
+					// only to (re)compute.
+					if (rankedVersion === mod.latestVersion && mod.latestDownloadUrl) {
+						await ensureVersionHashed(
+							req.params.modId,
+							rankedVersion,
+							mod.latestDownloadUrl,
+						)
+					}
+					const stillUnknown = !(await getStoredHash(req.params.modId, rankedVersion))
+					if (stillUnknown) {
+						throw new AppError(
+							rankedVersion === mod.latestVersion
+								? "Couldn't compute a hash for this mod's current version - check the server logs (mods-sync) for why the download/extraction failed, then try again"
+								: 'Not a known version of this mod',
+							400,
+						)
+					}
 				}
 			}
 			const ok = await setRankedVersion(req.params.modId, rankedVersion)
@@ -287,6 +317,22 @@ router.patch('/mods/:modId', async (req, res, next) => {
 
 		const mod = await updateModFields(req.params.modId, input)
 		if (!mod) throw new AppError('Mod not found', 404)
+
+		// See ensureVersionHashed()'s own comment for why this can't be left
+		// to the regular sync - an admin-resolved Branch/Release version has
+		// no other path to ever get a mod_registry_versions row or a hash at
+		// all otherwise. Only meaningful when resolved actually ran (Branch/
+		// Release mode) and produced a real version to hash - a 'branch' mod
+		// with an unreachable ref already threw out of resolveSourceInputField
+		// above, and Custom mode never reaches here since resolved stays null.
+		if (resolved?.latestVersion) {
+			await ensureVersionHashed(
+				req.params.modId,
+				resolved.latestVersion,
+				resolved.latestDownloadUrl,
+			)
+		}
+
 		res.json(mod)
 	} catch (err) {
 		next(err)
@@ -393,6 +439,19 @@ router.post('/mods', async (req, res, next) => {
 					: undefined,
 		})
 		if (!mod) throw new AppError(`A mod with id '${id}' already exists`, 409)
+
+		// See ensureVersionHashed()'s own comment. automaticVersionCheck being
+		// forced on above means the *next* sync would eventually reach this
+		// version too (via checkCustomModVersion() re-detecting the same
+		// value as "no change" and moving on to hashing it) - but that could
+		// be up to an hour away, and only re-detects successfully if nothing
+		// about the repo changed out from under it in the meantime. Hashing
+		// it immediately here instead means a freshly created Branch/Release
+		// mod is actually ranked-pinnable right away, not just eventually.
+		if (resolved?.latestVersion) {
+			await ensureVersionHashed(id, resolved.latestVersion, resolved.latestDownloadUrl)
+		}
+
 		res.status(201).json(mod)
 	} catch (err) {
 		next(err)

--- a/apps/server/src/infrastructure/gateways/mods.gateway.ts
+++ b/apps/server/src/infrastructure/gateways/mods.gateway.ts
@@ -337,6 +337,40 @@ export async function applyDetectedVersion(
 		})
 }
 
+// Upserts a single mod_registry_versions row for one exact modId+version -
+// the same shape applyDetectedVersion() above inserts inline for a custom
+// mod's detected version, generalized so mods-sync.service.ts's
+// ensureVersionHashed() can call it for *any* mod (custom or index-synced)
+// whose latestVersion/latestDownloadUrl an admin just resolved via a
+// Branch/Release source-type edit (see webadmin/mods.route.ts's
+// resolveSourceInputField). That admin-edit path used to update only the
+// mod_registry row itself - never mod_registry_versions - which meant the
+// edited version had no row for the regular sync's hashAll() to ever pick
+// up (hashAll()'s candidates come from the freshly-*fetched* upstream
+// index/custom-mod list, never from this table's or mod_registry's current
+// state - see mods-sync.service.ts's runSync() comment) and could never be
+// selected as a ranked-version pin either, since the admin UI's version
+// dropdown for a 'release' mod only offers what's already in this table.
+// Confirmed live: Blueprint's admin-overridden release tag ("v.3.3") had
+// no row here at all, months after the override - the regular sync's own
+// hash pass, and repeated manual "Sync now" clicks, could never have found
+// it no matter how many times either ran, since neither one ever looks at
+// what an admin already set outside the upstream-index/custom-mod-check
+// flow.
+export async function upsertVersionRow(
+	modId: string,
+	version: string,
+	downloadUrl: string,
+): Promise<void> {
+	await db
+		.insert(modRegistryVersions)
+		.values({ modId, version, downloadUrl })
+		.onConflictDoUpdate({
+			target: [modRegistryVersions.modId, modRegistryVersions.version],
+			set: { downloadUrl },
+		})
+}
+
 // --- Server-computed hashes (mods-sync.service.ts) ---
 
 // Null when never computed yet, or when the version's own row is missing


### PR DESCRIPTION
## Summary
Bug #1 from the current list (Blueprint). Confirmed live against production (`new.balatromp.com/api/mods/Blueprint`) before writing any code:

- `latestVersion`/`latestDownloadUrl` are correctly pinned to `"v.3.3"` (both in `overriddenFields` - the admin did edit this).
- `mod_registry_versions` has exactly **one** row: `"4e18c48"` - a stale branch-commit version from *before* the override to the release tag.
- `rankedVersion` is still stuck on that same stale `"4e18c48"` value.
- `latestSha256` is also stale, still mirroring that old hash.

**Root cause:** `resolveSourceInputField()` resolves a fresh `latestVersion`/`latestDownloadUrl` for an admin's Branch/Release source-type edit, but the PATCH/POST handlers that call it only ever wrote those two fields onto the `mod_registry` row - never into `mod_registry_versions`, and never computed a hash. That version then had no path to *ever* get hashed: the regular sync's hash-candidate list is built purely from the freshly-fetched upstream index entry (or, for a custom mod, `checkCustomModVersion()`'s own detection) - neither has any idea an admin manually pointed a mod somewhere else. It also couldn't even be *selected* as the ranked-version pin, since the admin UI's dropdown for a `'release'` mod only offers versions already present in `mod_registry_versions`.

## Fix
- `mods.gateway.ts`: `upsertVersionRow()` - single-row upsert, generalizing the insert `applyDetectedVersion()` already does inline for a custom mod.
- `mods-sync.service.ts`: `ensureVersionHashed()` - upserts the row, then computes+stores a hash right now if none exists (best-effort, logs rather than throws on failure).
- `webadmin/mods.route.ts`: calls `ensureVersionHashed()` right after a Branch/Release source resolves, in both `PATCH /mods/:modId` and `POST /mods`.
- `webadmin/mods.route.ts`: also added a recovery path directly in the ranked-version `PUT` handler - the admin edit dialog's PATCH is diff-based (only resends `sourceInput` when something in it actually changed), so an admin already stuck with an already-correct-looking-but-unhashed `latestVersion` (Blueprint's exact situation) had no way to re-trigger resolution from the edit dialog alone. Setting `rankedVersion` to exactly the mod's own current `latestVersion` now retries hashing once, on the spot, before rejecting.

## Testing
**Verified end-to-end against a real local Postgres, not just statically:**
- Spun up a local `postgres:16-alpine` container, ran `pnpm migrate` against it.
- Seeded `mod_registry`/`mod_registry_versions` to reproduce Blueprint's *exact* broken production state (verified moments earlier by reading it live): `latestVersion="v.3.3"`, `overriddenFields=["latestVersion","latestDownloadUrl"]`, `rankedVersion` stuck on the stale `"4e18c48"`, and exactly one `mod_registry_versions` row - for `"4e18c48"`, not `"v.3.3"`.
- Called the real `ensureVersionHashed()` with `stupxd/Blueprint`'s actual `v.3.3` tag URL - this did a real download+extract+hash of the real archive (not mocked), producing `e9a272de5254ad399879d3349608f30f3034363a3e20218dd9cbf3b4cfcd9f72`.
- Confirmed after: `mod_registry_versions` now has a second row for `"v.3.3"` with that real hash, `getStoredHash("Blueprint", "v.3.3")` returns it, and the exact condition `PUT /mods/:modId`'s validation checks (`mod.versions.some(v => v.version === rankedVersion)`) is now `true` where it was `false` before - i.e. rankedVersion="v.3.3" would now be accepted instead of rejected.
- Confirmed idempotency: calling `ensureVersionHashed()` a second time returns the same stored hash without re-downloading (the `getStoredHash` short-circuit fires correctly).
- Cleaned up: test container removed, scratch scripts and local `.env` deleted, nothing committed from the test run.
- `tsc --noEmit`: identical pre-existing errors before/after (none in the changed files - confirmed via `git stash`).
- `biome check`: clean on all three changed files (fixed one real `useTemplate` violation in my own new code; remaining findings are pre-existing `noNonNullAssertion`/CRLF-formatting issues on unrelated lines, confirmed via `git stash`).

**Once deployed:** re-editing Blueprint's Source in the admin panel with an actual change (or simply trying to set its Ranked Version to `"v.3.3"` again) will hash it successfully instead of silently no-op'ing/rejecting - confirmed above, this isn't speculative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)