### PR TITLE
Add the 'twelve' privilege -> j_stone avatar mapping

### DIFF
--- a/apps/server/src/shared/constants/jokers.ts
+++ b/apps/server/src/shared/constants/jokers.ts
@@ -40,6 +40,7 @@ export const PRIVILEGE_JOKERS: ReadonlyMap<string, string> = new Map([
 	['vagabond', 'j_vagabond'],
 	['sizaak', 'j_dusk'],
 	['lava', 'j_burnt'],
+	['twelve', 'j_stone'],
 ])
 
 export function isValidJoker(id: string, privileges: Privilege[] = []): boolean {


### PR DESCRIPTION
Same \`PRIVILEGE_JOKERS\` shape as \`virtualized\`/\`bean\`/\`vagabond\`/\`sizaak\`/\`lava\` - a player granted the \`twelve\` privilege (via \`PATCH /webadmin/players/:id/privileges\`) can now set \`j_stone\` as their \`preferredJoker\`.

No other changes needed - both consumers read the map generically:
- \`auth.service.ts\`'s \`setPreferredJoker\` (via \`isValidJoker\`) enforces it server-side on write.
- \`GET /jokers\` surfaces it to the website's avatar picker for anyone who actually has the privilege.

🤖 Generated with [Claude Code](https://claude.com/claude-code)